### PR TITLE
События в popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modul-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "ModulBank UI React Components",
   "main": "./lib",
   "module": "./source",

--- a/source/Popup/BaseModal.jsx
+++ b/source/Popup/BaseModal.jsx
@@ -20,6 +20,12 @@ const BaseModal = ({shouldCloseOnOverlayClick = true, children, isOpen, appEleme
 		}
 	};
 
+	// из-за portalCreate у нас события клика всплывают с модального окна в компонент где он был замуонтин
+	const preventEvents = e => {
+		e.preventDefault();
+		e.stopPropagation();
+	};
+
 	return (<Modal isOpen={isOpen}
 		portalClassName="poss"
 		contentLabel=""
@@ -29,7 +35,7 @@ const BaseModal = ({shouldCloseOnOverlayClick = true, children, isOpen, appEleme
 		onAfterOpen={onAfterOpen}
 		className="popup_table"
 		overlayClassName="popup_overlay">
-		<div className="popup_cell">
+		<div className="popup_cell" onClick={preventEvents}>
 			{children}
 			<div className="popup_backdrop" onClick={handleOverlayOnClick} />
 		</div>


### PR DESCRIPTION
Так как popup смонтирован через createPortal
То все события всплывают на то место, где был примонтирован попап
Остановил событие onClick, когда у тебя монтируется попап в div, при нажатии на который происходит открытие попапа, получается бага, при нажатии на крестик попапа событие onClick всплывает до div куда монтировался Popup и он снова открывается.

Это одно из решений, второе - не делать такого, оборачивать в React.Fragment и выносить модальное окно из области реагирования click

```
<React.Fragment>
<div onClick={() => this.popup.open()}>123</div>
<PopupContent....</PopupContent>
</React.Fragment>
```

Важно понимать что всплывут все события, но для click самое критичное